### PR TITLE
change flag for ndk support

### DIFF
--- a/freeglut/progs/test-shapes-gles1/ndk/jni/Application.mk
+++ b/freeglut/progs/test-shapes-gles1/ndk/jni/Application.mk
@@ -1,2 +1,2 @@
 APP_PLATFORM := android-9
-APP_STL := gnustl_static
+APP_STL := c++_static

--- a/liquidfun/Box2D/AndroidUtil/jni/Application.mk
+++ b/liquidfun/Box2D/AndroidUtil/jni/Application.mk
@@ -15,6 +15,6 @@
 # 3. This notice may not be removed or altered from any source distribution.
 APP_PLATFORM:=android-10
 APP_ABI:=armeabi-v7a
-APP_STL:=gnustl_static
+APP_STL:=c++_static
 APP_MODULES:=libandroidutil_static
 APP_CFLAGS+=-Wall -Werror -Wno-long-long -Wno-variadic-macros

--- a/liquidfun/Box2D/EyeCandy/jni/Application.mk
+++ b/liquidfun/Box2D/EyeCandy/jni/Application.mk
@@ -15,4 +15,4 @@
 # 3. This notice may not be removed or altered from any source distribution.
 APP_PLATFORM := android-10
 APP_PROJECT_PATH := $(call my-dir)/..
-APP_STL := gnustl_static
+APP_STL := c++_static

--- a/liquidfun/Box2D/HelloWorld/jni/Application.mk
+++ b/liquidfun/Box2D/HelloWorld/jni/Application.mk
@@ -16,7 +16,7 @@
 
 APP_PLATFORM := android-10
 APP_ABI:=armeabi-v7a
-APP_STL:=gnustl_static
+APP_STL:=c++_static
 NDK_MODULE_PATH+=$(abspath $(NDK_PROJECT_PATH)/../../)
 APP_MODULES:=HelloWorld
 APP_CFLAGS+=-Wall -Werror -Wno-long-long -Wno-variadic-macros

--- a/liquidfun/Box2D/Testbed/jni/Application.mk
+++ b/liquidfun/Box2D/Testbed/jni/Application.mk
@@ -15,7 +15,7 @@
 # 3. This notice may not be removed or altered from any source distribution.
 APP_PLATFORM := android-10
 APP_ABI:=armeabi-v7a
-APP_STL:=gnustl_static
+APP_STL:=c++_static
 NDK_MODULE_PATH+=$(subst $(space),,\
   $(abspath $(NDK_PROJECT_PATH)/../../)$(HOST_DIRSEP) \
   $(abspath $(NDK_PROJECT_PATH)/../../../))

--- a/liquidfun/Box2D/jni/Application.mk
+++ b/liquidfun/Box2D/jni/Application.mk
@@ -18,7 +18,7 @@ LOCAL_PATH:=$(call my-dir)
 
 APP_PLATFORM:=android-10
 APP_ABI:=armeabi-v7a
-APP_STL:=gnustl_static
+APP_STL:=c++_static
 APP_MODULES:=\
 	libliquidfun \
 	libliquidfun_static

--- a/liquidfun/Box2D/swig/jni/Application.mk
+++ b/liquidfun/Box2D/swig/jni/Application.mk
@@ -16,7 +16,7 @@
 
 APP_PLATFORM:=android-10
 APP_ABI:=armeabi-v7a
-APP_STL:=gnustl_static
+APP_STL:=c++_static
 APP_CFLAGS:=-DLIQUIDFUN_EXTERNAL_LANGUAGE_API=1
 NDK_MODULE_PATH+=$(abspath $(NDK_PROJECT_PATH)/../../)
 APP_MODULES:=libliquidfun_jni


### PR DESCRIPTION
New ndk not support `gnustl_static` flag, change to `c++_static`.
https://developer.android.com/ndk/guides/cpp-support